### PR TITLE
ECSOPS-239 Rename env var

### DIFF
--- a/config/custom-environment-variables-example.yaml
+++ b/config/custom-environment-variables-example.yaml
@@ -1,11 +1,11 @@
 server:
   hostname: 'API_HOSTNAME'
-  port: 'API_PORT'
-  adminPort: 'API_ADMIN_PORT'
+  port: 'PORT'
+  adminPort: 'ADMIN_PORT'
 
 authentication:
-  username: 'API_USER'
-  password: 'API_PASSWD'
+  username: 'USER'
+  password: 'PASSWD'
 
 database:
   connectString: 'DB_URL'

--- a/config/default-example.yaml
+++ b/config/default-example.yaml
@@ -1,16 +1,16 @@
 server:
   protocol: https
   hostname: ${API_HOSTNAME}
-  port: ${API_PORT}
-  adminPort: ${API_ADMIN_PORT}
+  port: ${PORT}
+  adminPort: ${ADMIN_PORT}
   basePathPrefix: /api
   keyPath: /path/to/key.pem
   certPath: /path/to/server.crt
   secureProtocol: TLSv1_2_method
 
 authentication:
-  username: ${API_USER}
-  password: ${API_PASSWD}
+  username: ${USER}
+  password: ${PASSWD}
 
 logger:
   size: 10m


### PR DESCRIPTION
It's my bad that I forgot we also use these env vars for the [health check](https://github.com/osu-mist/ansible-roles/blob/master/roles/api-environment/templates/express-api/start-express-container.sh.j2#L60-L72), so we should rename them back in the skeleton.