### PR TITLE
Close connection after validation is done

### DIFF
--- a/api/v1/db/oracledb/connection.js
+++ b/api/v1/db/oracledb/connection.js
@@ -42,6 +42,7 @@ const validateOracleDb = async () => {
     connection = await getConnection();
     await connection.execute('SELECT 1 FROM DUAL');
   } catch (err) {
+    console.error(err);
     throw new Error('Unable to connect to Oracle database');
   } finally {
     connection.close();

--- a/api/v1/db/oracledb/connection.js
+++ b/api/v1/db/oracledb/connection.js
@@ -37,11 +37,14 @@ const getConnection = () => new Promise(async (resolve, reject) => {
  * @throws Throws an error if unable to connect to the database
  */
 const validateOracleDb = async () => {
+  let connection;
   try {
-    const connection = await getConnection();
+    connection = await getConnection();
     await connection.execute('SELECT 1 FROM DUAL');
   } catch (err) {
     throw new Error('Unable to connect to Oracle database');
+  } finally {
+    connection.close();
   }
 };
 


### PR DESCRIPTION
@Ruefa ran into the issue that if we only set exactly one pool, the connection will be occupied by the validation and the rest requests won't be able to connect to the DB. This change will need to be brought to terms api and students api.