### PR TITLE
CO-1472: improve schema validation responses

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -173,25 +173,25 @@ components:
       properties:
         self:
           type: string
-          format: url
+          format: uri
           description: Self-link of current resource
     PaginationLinks:
       properties:
         first:
           type: string
-          format: url
+          format: uri
           description: The first page of data
         last:
           type: string
-          format: url
+          format: uri
           description: The last page of data
         prev:
           type: string
-          format: url
+          format: uri
           description: The previous page of data
         next:
           type: string
-          format: url
+          format: uri
           description: The next page of data
     PetResource:
       properties:
@@ -286,7 +286,7 @@ components:
           properties:
             about:
               type: string
-              format: url
+              format: uri
               description: A link to further information about the error
               example: https://developer.oregonstate.edu/documentation/error-reference#1234
     ErrorResult:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -188,10 +188,12 @@ components:
         prev:
           type: string
           format: uri
+          nullable: true
           description: The previous page of data
         next:
           type: string
           format: uri
+          nullable: true
           description: The next page of data
     PetResource:
       properties:

--- a/package-lock.json
+++ b/package-lock.json
@@ -927,9 +927,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         },
         "source-map": {
@@ -1260,9 +1260,9 @@
       }
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -5750,12 +5750,6 @@
         "plugin-error": "^1.0.1"
       },
       "dependencies": {
-        "acorn": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-          "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
-          "dev": true
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -5983,9 +5977,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         },
         "source-map": {

--- a/src/api-routes/pets.js
+++ b/src/api-routes/pets.js
@@ -9,7 +9,7 @@ import { serializePet, serializePets } from '../serializers/pets-serializer';
  */
 const get = async (req, res) => {
   try {
-    const rawPets = await getPets(req);
+    const rawPets = await getPets(req.query);
     const result = serializePets(rawPets, req);
     return res.send(result);
   } catch (err) {

--- a/src/api-routes/pets.js
+++ b/src/api-routes/pets.js
@@ -9,7 +9,7 @@ import { serializePet, serializePets } from '../serializers/pets-serializer';
  */
 const get = async (req, res) => {
   try {
-    const rawPets = await getPets(req.query);
+    const rawPets = await getPets(req);
     const result = serializePets(rawPets, req);
     return res.send(result);
   } catch (err) {

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ import { bodyParserError } from 'middlewares/body-parser-error';
 import { loggerMiddleware } from 'middlewares/logger';
 import { removeUnknownParams } from 'middlewares/remove-unknown-params';
 import { runtimeErrors } from 'middlewares/runtime-errors';
+import { validateAllResponses } from 'middlewares/validate-all-responses';
 import { openapi } from 'utils/load-openapi';
 import { validateDataSource } from 'utils/validate-data-source';
 
@@ -103,7 +104,8 @@ initialize({
   app: appRouter,
   apiDoc: {
     ...openapi,
-    'x-express-openapi-additional-middleware': [removeUnknownParams],
+    'x-express-openapi-additional-middleware': [removeUnknownParams, validateAllResponses],
+    'x-express-openapi-validation-strict': false,
   },
   paths: 'dist/api-routes',
   consumesMiddleware: {

--- a/src/db/oracledb/pets-dao-example.js
+++ b/src/db/oracledb/pets-dao-example.js
@@ -6,12 +6,13 @@ import { contrib } from './contrib/contrib';
 /**
  * Return a list of pets
  *
+ * @param {object} query Query parameters
  * @returns {Promise<object>[]} Promise object represents a list of pets
  */
-const getPets = async () => {
+const getPets = async (query) => {
   const connection = await getConnection();
   try {
-    const { rawPets } = await connection.execute(contrib.getPets());
+    const { rawPets } = await connection.execute(contrib.getPets(query));
     return rawPets;
   } finally {
     connection.close();

--- a/src/db/oracledb/pets-dao-example.js
+++ b/src/db/oracledb/pets-dao-example.js
@@ -1,23 +1,18 @@
-import config from 'config';
 import _ from 'lodash';
 
-import { serializePets, serializePet } from 'serializers/pets-serializer';
 import { getConnection } from './connection';
 import { contrib } from './contrib/contrib';
-
-const { endpointUri } = config.get('server');
 
 /**
  * Return a list of pets
  *
- * @returns {Promise<object[]>} Promise object represents a list of pets
+ * @returns {Promise<object>[]} Promise object represents a list of pets
  */
 const getPets = async () => {
   const connection = await getConnection();
   try {
     const { rawPets } = await connection.execute(contrib.getPets());
-    const serializedPets = serializePets(rawPets, endpointUri);
-    return serializedPets;
+    return rawPets;
   } finally {
     connection.close();
   }
@@ -42,8 +37,7 @@ const getPetById = async (id) => {
       throw new Error('Expect a single object but got multiple results.');
     } else {
       const [rawPet] = rawPets;
-      const serializedPet = serializePet(rawPet);
-      return serializedPet;
+      return rawPet;
     }
   } finally {
     connection.close();

--- a/src/middlewares/validate-all-responses.js
+++ b/src/middlewares/validate-all-responses.js
@@ -1,0 +1,44 @@
+import { errorHandler } from 'errors/errors';
+
+/**
+ * Middleware that overrides res.send to perform response validation
+ *
+ * @type {RequestHandler}
+ */
+const validateAllResponses = (req, res, next) => {
+  const strictValidation = req.apiDoc['x-express-openapi-validation-strict'];
+  if (typeof res.validateResponse === 'function') {
+    const { send } = res;
+    res.send = (...args) => {
+      const onlyWarn = !strictValidation;
+      if (res.get('x-express-openapi-validation-error-for') !== undefined) {
+        return send.apply(res, args);
+      }
+      const body = args[0];
+      let validation = res.validateResponse(res.statusCode, body);
+      let validationMessage;
+      if (validation === undefined) {
+        validation = { message: undefined, errors: undefined };
+      }
+      if (validation.errors) {
+        let errors;
+        try {
+          errors = JSON.stringify(validation.errors, null, 2);
+        } catch (err) {
+          return errorHandler(res, err);
+        }
+        validationMessage = `Invalid response for status code ${res.statusCode}: ${errors}`;
+        console.warn(validationMessage);
+        // Set to avoid a loop, and to provide the original status code
+        res.set('x-express-openapi-validation-error-for', res.statusCode.toString());
+      }
+      if (onlyWarn || !validation.errors) {
+        return send.apply(res, args);
+      }
+      return errorHandler(res, validationMessage);
+    };
+  }
+  next();
+};
+
+export { validateAllResponses };


### PR DESCRIPTION
* Fixes the oracledb pets DAO example (unrelated to this ticket)
* Updates openapi document to use `uri` format instead of `url` (which would cause a false positive when validating due to the deprecated `url` [ajv format](https://github.com/epoberezkin/ajv#formats)
* Adds global response validation with default behavior of printing a warning message for failed validation. Enabling strict validation would respond with a 500.