### PR TITLE
Boolean unit tests only work with pets openapi

### DIFF
--- a/src/tests/unit/validate-boolean-params.test.js
+++ b/src/tests/unit/validate-boolean-params.test.js
@@ -10,6 +10,23 @@ describe('Test validate-boolean-params', () => {
 
   const validateProxy = proxyquire('middlewares/validate-boolean-params', {
     '../errors/errors': { errorBuilder: () => { throw err; } },
+    '../utils/load-openapi': {
+      openapi: {
+        paths: [
+          [
+            {
+              parameters: [
+                {
+                  in: 'query',
+                  schema: { type: 'boolean' },
+                  name: 'filter[hasOwner]',
+                },
+              ],
+            },
+          ],
+        ],
+      },
+    },
   });
 
   let testCases = ['test', 'cats', 1, true, undefined, null];


### PR DESCRIPTION
validate booleans middleware unit tests were assuming that the openapi would have a `filter[hasOwner]` query parameter. Only pets api has this so we must stub `load-openapi` to ensure it has one when tests run under other APIs.